### PR TITLE
update cargo_toml version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ name = "publish-action"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cargo_toml = "0.11.5"
+cargo_toml = "0.13.0"
 crates_io_api = "0.8.0"
 dotenv = "0.15.0"
 futures = "0.3.21"

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@
 
 use std::io::Read;
 use crates_io_api::{SyncClient};
-use cargo_toml::Manifest;
+use cargo_toml::{Inheritable, Manifest};
 use version_compare::{Cmp, compare_to};
 use std::process::Command;
 use dotenv::dotenv;
@@ -81,7 +81,13 @@ fn get_new_info(path: &str) -> Presult<(String,String)> {
     let info = Manifest::from_slice(&content)?;
 
     match info.package {
-        Some(v) => Ok((v.name,v.version)),
+        Some(v) => {
+            let version = match v.version {
+                Inheritable::Set(version) => version,
+                Inheritable::Inherited{..} => panic!("Inherited versions not yet supported")
+            };
+            Ok((v.name,version))
+        },
         None => Err(Perror::Input("not found version in Cargo.toml".to_string()))
     }
 }


### PR DESCRIPTION
I noticed this dependency was out of date. I've done just enough change to use the new version correctly -  a future step if you want workspace support would be to implement the inheritance lookup.