### PR TITLE
Fix #2: Publish to private registries

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,19 @@
+name: Security audit
+
+on:
+  schedule:
+    - cron: "0 0 1 * *"
+  push:
+    paths:
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+  pull_request:
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Audit dependencies
+        uses: actions-rs/audit-check@v1

--- a/.github/workflows/ci-matrix.yml
+++ b/.github/workflows/ci-matrix.yml
@@ -1,0 +1,48 @@
+on: [push, pull_request]
+name: CI
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: setup rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+          components: rustfmt, clippy
+
+      - name: setup caching
+        uses: Swatinem/rust-cache@v2
+
+      - name: build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+
+      - name: test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+      - name: fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+      - name: clippy
+        if: ${{ matrix.rust == 'stable' }}
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --all-features -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,11 @@ name = "publish-action"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cargo_toml = "0.11.5"
-crates_io_api = "0.8.0"
+anyhow = "1.0.66"
+cargo = "0.66.0"
 dotenv = "0.15.0"
 futures = "0.3.21"
 json = "0.12.4"
 thiserror = "1.0"
 #openssl = "0.10.40"
-reqwest = { version = "0.11.10", features = ["blocking"] }
-version-compare = "0.1.0"
+reqwest = { version = "0.11.10", features = ["blocking", "json"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "publish-action"
-version = "0.1.16"
-edition = "2021"
-license = "MIT"
-description = "Auto Publish Cargo with Github Action"
-keywords = ["github-action", "cargo","CI-CD", "publish"]
-repository = "https://github.com/tu6ge/publish-action"
 authors = ["tu6ge <772364230@qq.com>"]
+description = "Auto Publish Cargo with Github Action"
+edition = "2021"
+keywords = ["github-action", "cargo", "CI-CD", "publish"]
+license = "MIT"
+name = "publish-action"
+repository = "https://github.com/tu6ge/publish-action"
+version = "0.1.16"
 
 [[bin]]
 name = "publish-action"
@@ -18,8 +18,8 @@ cargo_toml = "0.11.5"
 crates_io_api = "0.8.0"
 dotenv = "0.15.0"
 futures = "0.3.21"
-thiserror = "1.0"
 json = "0.12.4"
+thiserror = "1.0"
 #openssl = "0.10.40"
-reqwest = {version ="0.11.10",features= ["blocking"]}
+reqwest = { version = "0.11.10", features = ["blocking"] }
 version-compare = "0.1.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,36 +1,36 @@
 use thiserror::Error;
 
 #[derive(Error, Debug)]
-pub enum Perror{
-  #[error("reqwest error")]
-  Request(#[from] reqwest::Error),
+pub enum Perror {
+    #[error("reqwest error")]
+    Request(#[from] reqwest::Error),
 
-  #[error("{0}")]
-  Dotenv(#[from] dotenv::Error),
+    #[error("{0}")]
+    Dotenv(#[from] dotenv::Error),
 
-  #[error("var error")]
-  VarError(#[from] std::env::VarError),
+    #[error("var error")]
+    VarError(#[from] std::env::VarError),
 
-  #[error("json error")]
-  JsonError(#[from] json::JsonError),
+    #[error("json error")]
+    JsonError(#[from] json::JsonError),
 
-  #[error("input data is not valid")]
-  Input(String),
+    #[error("input data is not valid")]
+    Input(String),
 
-  #[error("github api return error")]
-  Github(String),
+    #[error("github api return error")]
+    Github(String),
 
-  #[error("io error {0}")]
-  Io(#[from] std::io::Error),
+    #[error("io error {0}")]
+    Io(#[from] std::io::Error),
 
-  #[error("CargoToml error {0}")]
-  CargoToml(#[from] cargo_toml::Error),
+    #[error("CargoToml error {0}")]
+    CargoToml(#[from] cargo_toml::Error),
 
-  #[error("InvalidHeaderValue {0}")]
-  InvalidHeaderValue(#[from] reqwest::header::InvalidHeaderValue),
+    #[error("InvalidHeaderValue {0}")]
+    InvalidHeaderValue(#[from] reqwest::header::InvalidHeaderValue),
 
-  #[error("crates io api error {0}")]
-  CratesIoApi(#[from] crates_io_api::Error)
+    #[error("crates io api error {0}")]
+    CratesIoApi(#[from] crates_io_api::Error),
 }
 
-pub type Presult<T> = Result<T,Perror>;
+pub type Presult<T> = Result<T, Perror>;

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,14 +23,17 @@ pub enum Perror {
     #[error("io error {0}")]
     Io(#[from] std::io::Error),
 
-    #[error("CargoToml error {0}")]
-    CargoToml(#[from] cargo_toml::Error),
-
     #[error("InvalidHeaderValue {0}")]
     InvalidHeaderValue(#[from] reqwest::header::InvalidHeaderValue),
 
-    #[error("crates io api error {0}")]
-    CratesIoApi(#[from] crates_io_api::Error),
+    /// Cargo uses anyhow::Result which uses anyhow::Error, but not publically
+    /// exposed, so we must match the version of anyhow with the one cargo gets
+    /// built with.
+    #[error("cargo library error {0}")]
+    CargoError(#[from] anyhow::Error),
+
+    #[error("Publishing disabled")]
+    PublishingDisabled,
 }
 
 pub type Presult<T> = Result<T, Perror>;

--- a/src/github.rs
+++ b/src/github.rs
@@ -1,97 +1,93 @@
-/**!
- * # Github API SDK
- */
+//! # Github API SDK
 
-use reqwest::{blocking, Method};
-use json::JsonValue;
 use std::collections::HashMap;
 
-use crate::error::{Perror,Presult};
+use crate::error::{Perror, Presult};
+use json::JsonValue;
+use reqwest::{blocking, Method};
 
-pub struct Github<'a>{
-  repositroy: &'a str,
-  token: &'a str,
+pub struct Github<'a> {
+    repositroy: &'a str,
+    token: &'a str,
 }
 
-impl <'a> Github<'a>{
-
-  pub fn new(repositroy: &'a str, token: &'a str) -> Github<'a> {
-    Github { 
-      repositroy,
-      token,
-    }
-  }
-
-  /// # Build reqwest client with gihub common configure
-  /// [github doc](https://docs.github.com/cn/rest/git/)
-  pub fn client(&self, method: Method, url: &str, body: Option<HashMap<&str, &str>>) -> Presult<JsonValue>
-  {
-    //dotenv()?;
-
-    let client_inner = blocking::Client::builder().build()?;
-    let mut auth = String::from("token ");
-    auth.push_str(self.token);
-
-    let mut full_url = String::from("https://api.github.com/repos/");
-    full_url.push_str(self.repositroy);
-    full_url.push('/');
-    full_url.push_str(url);
-
-    let mut request = client_inner.request(method, full_url)
-      .header("Authorization", auth)
-      .header("User-Agent","tu6ge(772364230@qq.com)")
-      .header("Accept", "application/vnd.github.v3+json");
-
-    if let Some(body) = body {
-      request = request.json(&body)
+impl<'a> Github<'a> {
+    pub fn new(repositroy: &'a str, token: &'a str) -> Github<'a> {
+        Github { repositroy, token }
     }
 
-    let response = request.send()?;
-    
-    if response.status() != 200 && response.status() !=201 && response.status() != 204{
-      return Err(Perror::Github(response.text()?));
+    /// # Build reqwest client with gihub common configure
+    /// [github doc](https://docs.github.com/cn/rest/git/)
+    pub fn client(
+        &self,
+        method: Method,
+        url: &str,
+        body: Option<HashMap<&str, &str>>,
+    ) -> Presult<JsonValue> {
+        //dotenv()?;
+
+        let client_inner = blocking::Client::builder().build()?;
+        let mut auth = String::from("token ");
+        auth.push_str(self.token);
+
+        let mut full_url = String::from("https://api.github.com/repos/");
+        full_url.push_str(self.repositroy);
+        full_url.push('/');
+        full_url.push_str(url);
+
+        let mut request = client_inner
+            .request(method, full_url)
+            .header("Authorization", auth)
+            .header("User-Agent", "tu6ge(772364230@qq.com)")
+            .header("Accept", "application/vnd.github.v3+json");
+
+        if let Some(body) = body {
+            request = request.json(&body)
+        }
+
+        let response = request.send()?;
+
+        if response.status() != 200 && response.status() != 201 && response.status() != 204 {
+            return Err(Perror::Github(response.text()?));
+        }
+
+        if response.status() == 204 {
+            return Ok(JsonValue::new_object());
+        }
+
+        let result = json::parse(&response.text()?)?;
+        Ok(result)
     }
 
-    if response.status() == 204 {
-      return Ok(JsonValue::new_object());
+    /// # Get git sha of git head
+    pub fn get_sha(&self, head: &str) -> Presult<String> {
+        let url = String::from("git/matching-refs/heads/") + head;
+        let json = self.client(Method::GET, &url, None)?;
+        let sha: String = json[0]["object"]["sha"].to_string();
+        Ok(sha)
     }
 
-    let result = json::parse(&response.text()?)?;
-    Ok(result)
-  }
+    /// # Set tag ref by git sha
+    pub fn set_ref(&self, tag: &str, sha: &str) -> Presult<()> {
+        let url = "git/refs";
+        let mut body = HashMap::new();
 
-  /// # Get git sha of git head
-  pub fn get_sha(&self, head: &str) -> Presult<String>{
-    let url = String::from("git/matching-refs/heads/") + head;
-    let json = self.client(Method::GET, &url, None)?;
-    let sha: String = json[0]["object"]["sha"].to_string();
-    Ok(sha)
-  }
-  
-  /// # Set tag ref by git sha
-  pub fn set_ref(&self, tag: &str, sha: &str) -> Presult<()>{
-    let url = "git/refs";
-    let mut body = HashMap::new();
-  
-    let mut tag_string = String::from("refs/tags/");
-    tag_string.push_str(tag);
-    
-    body.insert("ref", tag_string.as_str());
-    body.insert("sha", sha);
-  
-    self.client(Method::POST, url, Some(body))?;
-    Ok(())
-  }
-  
-  #[allow(dead_code)]
-  /// # delete git ref
-  pub fn del_ref(&self) -> Presult<()>{
-    let url = "git/refs/tags/dev-0.2.0";
-  
-    self.client(Method::DELETE, url, None)?;
-    Ok(())
-  }
+        let mut tag_string = String::from("refs/tags/");
+        tag_string.push_str(tag);
+
+        body.insert("ref", tag_string.as_str());
+        body.insert("sha", sha);
+
+        self.client(Method::POST, url, Some(body))?;
+        Ok(())
+    }
+
+    #[allow(dead_code)]
+    /// # delete git ref
+    pub fn del_ref(&self) -> Presult<()> {
+        let url = "git/refs/tags/dev-0.2.0";
+
+        self.client(Method::DELETE, url, None)?;
+        Ok(())
+    }
 }
-
-
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,12 +18,12 @@ fn main() -> Presult<()> {
 
     dotenv().ok();
 
-    let repositroy = env::var("GITHUB_REPOSITORY")?;
+    let repository = env::var("GITHUB_REPOSITORY")?;
     let branch = env::var("GITHUB_REF_NAME")?;
     let token = env::var("GITHUB_TOKEN")?;
     let path = env::var("GITHUB_WORKSPACE")?;
 
-    println!("repositroy: {}", repositroy);
+    println!("repository: {}", repository);
 
     let (name, version) = get_new_info(&path)?;
     println!("name: {}, version: {}", name, version);
@@ -49,7 +49,7 @@ fn main() -> Presult<()> {
         return Err(Perror::Input("publish command failed".to_string()));
     }
 
-    let gh = github::Github::new(&repositroy, &token);
+    let gh = github::Github::new(&repository, &token);
     let sha = gh.get_sha(&branch)?;
     println!("sha: {}", sha);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ fn main() -> Presult<()> {
     let published_version = get_published_version(&name)?;
     println!("published version: {}", published_version);
 
-    if compare_to(&version, &published_version, Cmp::Gt).unwrap() == false {
+    if !compare_to(&version, &published_version, Cmp::Gt).unwrap() {
         println!("not find new version");
         println!("::set-output name=new_version::false");
         return Ok(());
@@ -44,7 +44,7 @@ fn main() -> Presult<()> {
         .arg("publish")
         .current_dir(&path)
         .status()?;
-    if com_res.success() == false {
+    if !com_res.success() {
         println!("::set-output name=publish::false");
         return Err(Perror::Input("publish command failed".to_string()));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,7 @@
 //extern crate openssl;
 
-use std::env;
-use std::io::Read;
 use std::process::Command;
+use std::{env, path::PathBuf};
 
 use crate::error::{Perror, Presult};
 use cargo_toml::Manifest;
@@ -69,18 +68,12 @@ fn get_published_version(name: &str) -> Presult<String> {
     Ok(summary.crate_data.max_version)
 }
 
-fn get_new_info(path: &str) -> Presult<(String, String)> {
-    let mut content: Vec<u8> = Vec::new();
-    let mut path = String::from(path);
-    path.push_str("/Cargo.toml");
+fn get_new_info(dir: &str) -> Presult<(String, String)> {
+    let mut cargo_toml = PathBuf::from(dir);
+    cargo_toml.push("Cargo.toml");
+    let manifest = Manifest::from_path(&cargo_toml)?;
 
-    //println!("path {}", path);
-
-    std::fs::File::open(path)?.read_to_end(&mut content)?;
-
-    let info = Manifest::from_slice(&content)?;
-
-    match info.package {
+    match manifest.package {
         Some(v) => Ok((v.name, v.version)),
         None => Err(Perror::Input("not found version in Cargo.toml".to_string())),
     }


### PR DESCRIPTION
Use the `cargo` API to perform resolution of published versions rather than crates_io_api. This permits alternate registries to work (public or private) as well as the public default registry `crates.io`.

With the default registry it looks like so:

```
$ GITHUB_WORKSPACE=. GITHUB_REPOSITORY=XXX GITHUB_REF_NAME=XXX GITHUB_TOKEN=XXX  cargo run
    Updating crates.io index
     Running `git fetch --force --update-head-ok 'https://github.com/rust-lang/crates.io-index' '+HEAD:refs/remotes/origin/HEAD'`
repository: XXX
name: publish-action, version: 0.1.16
publication status: [Published]
::set-output name=new_version::false
already published
```

With an alternative registry it looks like so:

```
GITHUB_WORKSPACE=../path/to/private/crate GITHUB_REPOSITORY=XXX GITHUB_REF_NAME=XXX GITHUB_TOKEN=XXX  cargo run
    Updating `private-registry` index
     Running `git fetch --force --update-head-ok 'https://xxx.example/path-to-registry.git' '+HEAD:refs/remotes/origin/HEAD'`
repository: bad
name: crate_name, version: 0.1.0
publication status: [NotPublished]
::set-output name=new_version::true
version not published
...(cargo publish output here)...
::set-output name=publish::false
```