### PR TITLE
Fix missing `v` in version tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ jobs:
           fetch-depth: 0
       
       - name: Run publish-action
-        uses: tu6ge/publish-action@0.4.5
+        uses: tu6ge/publish-action@v0.4.5
         env:
           # This can help you tagging the github repository
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -109,7 +109,7 @@ jobs:
           fetch-depth: 0
       
       - name: Run publish-action
-        uses: tu6ge/publish-action@0.4.5
+        uses: tu6ge/publish-action@v0.4.5
         env:
           # This can help you tagging the github repository
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The version tag for 0.4.1+ starts with a `v` but the examples miss this.